### PR TITLE
Make “crunch bangs” use /usr/bin/env to support NixOS

### DIFF
--- a/tools/compile-prelude.sh
+++ b/tools/compile-prelude.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd ./src;

--- a/tools/make-latex.sh
+++ b/tools/make-latex.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd ./src; sbcl --script ./main-latex.cl \


### PR DESCRIPTION
Hey, this project is really cool! 

I tried compiling it on NixOS, but due to the way NixOS works, the crunchbangs can't reference /bin/bash.

Doing it this way however, I was able to build the project without issues.

It would probably (but I haven't tested) be fine to change them to /bin/sh as well, but this pattern is maybe better? 

